### PR TITLE
Support cross platform paths on chat page

### DIFF
--- a/src/Azure.CognitiveService.Client.BlazorApp/Pages/Chat/Chat.razor
+++ b/src/Azure.CognitiveService.Client.BlazorApp/Pages/Chat/Chat.razor
@@ -1,4 +1,4 @@
-﻿@page "/chat"
+@page "/chat"
 
 @using Azure.CognitiveService.Client
 @using Azure.CognitiveService.Client.BlazorApp.Data;
@@ -133,7 +133,8 @@
 
     private void LoadExamples()
     {
-        var json = File.ReadAllText($"{System.IO.Directory.GetCurrentDirectory()}{@"\wwwroot\ExampleChats.json"}");
+        var path = Path.Combine(System.IO.Directory.GetCurrentDirectory(), "wwwroot", "ExampleChats.json");
+        var json = File.ReadAllText(path);
         SearchModelExamples = JsonSerializer.Deserialize<List<ChatSearchModel>>(json);
         SelectedSearchModel = SearchModelExamples.First();
     }


### PR DESCRIPTION
Changes the ExampleChats.json file read to not use separator chars, allowing build on macOS and some containers